### PR TITLE
The initial OBS import

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+sudo: required
+language: ruby
+services:
+  - docker
+
+before_install:
+  - docker build -t patterns-yast-image .
+script:
+  # the "yast-travis-ruby" script is included in the base yastdevel/ruby image
+  # see https://github.com/yast/docker-yast-ruby/blob/master/yast-travis-ruby
+  - docker run -it -e TRAVIS_JOB_ID="$TRAVIS_JOB_ID" patterns-yast-image yast-travis-ruby

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,89 @@
+YaST Contribution Guidelines
+============================
+
+YaST is an open source project and as such it welcomes all kinds of
+contributions. If you decide to contribute, please follow these guidelines to
+ensure the process is effective and pleasant both for you and the YaST maintainers.
+
+There are two main forms of contribution: reporting bugs and performing code
+changes.
+
+Bug Reports
+-----------
+
+If you find a problem, please report it either using
+[Bugzilla](https://bugzilla.suse.com/enter_bug.cgi?format=guided&product=openSUSE+Factory&component=YaST2)
+or [GitHub issues](../../issues). (For Bugzilla, use the [simplified
+registration](https://secure-www.novell.com/selfreg/jsp/createSimpleAccount.jsp)
+if you don't have an account yet.)
+
+When creating a bug report, please follow our [bug reporting
+guidelines](http://en.opensuse.org/openSUSE:Report_a_YaST_bug).
+
+We can't guarantee that every bug will be fixed, but we'll try.
+
+Code Changes
+------------
+
+We welcome all kinds of code contributions, from simple bug fixes to significant
+refactorings and implementation of new features. However, before making any
+non-trivial contribution, get in touch with us first — this can prevent wasted
+effort on both sides. Also, have a look at our [development
+documentation](http://en.opensuse.org/openSUSE:YaST_development).
+
+To send us your code change, use GitHub pull requests. The workflow is as
+follows:
+
+  1. Fork the project.
+
+  2. Create a topic branch based on `master`.
+
+  3. Implement your change, including tests (if possible). Make sure you adhere
+     to the [Ruby style
+     guide](https://github.com/SUSE/style-guides/blob/master/Ruby.md).
+
+  4. Update the package version (in `packages/*.spec`, usually by
+     `rake version:bump`) and add a new entry to the `package/*.changes` file
+     (by `osc vc package`).  
+     For bigger changes or changes which need longer discussion it is advised to
+     add this as a separate last commit so it can be easily updated when another
+     change is merged in the meantime.
+
+  5. Make sure your change didn't break anything by building the RPM package
+     (`rake osc:build`). The build process includes running the full testsuite.
+
+  6. Publish the branch and create a pull request.
+
+  7. YaST developers will review your change and possibly point out issues.
+     Adapt the code under their guidance until they are all resolved.
+
+  8. Finally, the pull request will get merged or rejected.
+
+See also [GitHub's guide on
+contributing](https://help.github.com/articles/fork-a-repo).
+
+If you want to do multiple unrelated changes, use separate branches and pull
+requests.
+
+### Commits
+
+Each commit in the pull request should do only one thing, which is clearly
+described by its commit message. Especially avoid mixing formatting changes and
+functional changes into one commit. When writing commit messages, adhere to
+[widely used
+conventions](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
+
+If your commit is related to a bug in Bugzilla or an issue on GitHub, make sure
+you mention it in the commit message for cross-reference. Use format like
+bnc#775814 or gh#yast/yast-foo#42. See also [GitHub
+autolinking](https://help.github.com/articles/github-flavored-markdown#references)
+and [openSUSE abbreviation
+reference](http://en.opensuse.org/openSUSE:Packaging_Patches_guidelines#Current_set_of_abbreviations).
+
+Additional Information
+----------------------
+
+If you have any question, feel free to ask at the [development mailing
+list](http://lists.opensuse.org/yast-devel/) or at the
+[#yast](http://webchat.freenode.net/?channels=%23yast) IRC channel on freenode.
+We'll do our best to provide a timely and accurate answer.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,3 @@
+FROM yastdevel/ruby
+COPY . /usr/src/app
+

--- a/README.md
+++ b/README.md
@@ -1,0 +1,27 @@
+YaST - The Pattern Definitions
+==============================
+
+[![Travis Build Status](
+https://travis-ci.org/yast/patterns-yast.svg?branch=master)](https://travis-ci.org/yast/patterns-yast)
+
+This meta package defines the YaST software patters which can be installed using
+the package manager.
+
+
+Getting the Sources
+===================
+
+To get the source code, clone the GitHub repository:
+
+    git clone https://github.com/yast/patters-yast.git
+
+If you want to contribute into the project you can
+[fork](https://help.github.com/articles/fork-a-repo/) the repository and clone your fork.
+
+
+Contact
+=======
+
+If you have any question, feel free to ask at the [development mailing
+list](http://lists.opensuse.org/yast-devel/) or at the
+[#yast](https://webchat.freenode.net/?channels=%23yast) IRC channel on freenode.

--- a/RPMNAME
+++ b/RPMNAME
@@ -1,0 +1,1 @@
+patterns-yast

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,29 @@
+require "yast/rake"
+
+Yast::Tasks.configuration do |conf|
+  # lets ignore license check for now
+  conf.skip_license_check << /.*/
+end
+
+# do not create a tarball, this package contains only a .spec file
+Rake::Task["tarball"].clear_actions
+
+# redefine the version:bump task, this package uses a date as the version number
+Rake::Task["version:bump"].clear
+
+namespace :version do
+  desc "Set the version number in the package/*.spec file to the current date"
+  task :bump do
+    new_version = Time.now.strftime("%Y%m%d")
+    puts "Updating version to #{new_version}"
+
+    # update all present *.spec files
+    Dir.glob("package/*.spec").each do |spec_file|
+      spec = File.read(spec_file)
+      spec.gsub!(/^\s*Version:.*$/, "Version:        #{new_version}")
+
+      File.write(spec_file, spec)
+    end
+  end
+end
+

--- a/Rakefile
+++ b/Rakefile
@@ -1,9 +1,11 @@
-require "yast/rake"
+# Copyright (c) 2017 SUSE LINUX GmbH, Nuernberg, Germany.
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License.
+#
 
-Yast::Tasks.configuration do |conf|
-  # lets ignore license check for now
-  conf.skip_license_check << /.*/
-end
+require "yast/rake"
 
 # do not create a tarball, this package contains only a .spec file
 Rake::Task["tarball"].clear_actions

--- a/package/patterns-yast-rpmlintrc
+++ b/package/patterns-yast-rpmlintrc
@@ -1,0 +1,3 @@
+addFilter("W: no-binary");
+
+

--- a/package/patterns-yast.changes
+++ b/package/patterns-yast.changes
@@ -1,0 +1,4 @@
+-------------------------------------------------------------------
+Thu Mar 16 06:15:40 UTC 2017 - sflees@suse.de
+
+- Create new package from old unified patterns package

--- a/package/patterns-yast.spec
+++ b/package/patterns-yast.spec
@@ -1,0 +1,306 @@
+#
+# spec file for package patterns-openSUSE
+#
+# Copyright (c) 2017 SUSE LINUX GmbH, Nuernberg, Germany.
+#
+# All modifications and additions to the file contributed by third parties
+# remain the property of their copyright owners, unless otherwise agreed
+# upon. The license for this file, and modifications and additions to the
+# file, is the same license as for the pristine package itself (unless the
+# license for the pristine package is not an Open Source License, in which
+# case the license is the MIT License). An "Open Source License" is a
+# license that conforms to the Open Source Definition (Version 1.9)
+# published by the Open Source Initiative.
+
+# Please submit bugfixes or comments via http://bugs.opensuse.org/
+#
+
+
+%bcond_with betatest
+
+Name:           patterns-yast
+Version:        20170319
+Release:        0
+Summary:        Patterns for Installation (Yast)
+License:        MIT
+Group:          Metapackages
+Url:            https://github.com/openSUSE/patterns
+Source0:        %{name}-rpmlintrc
+BuildRoot:      %{_tmppath}/%{name}-%{version}-build
+BuildRequires:  patterns-rpm-macros
+
+
+%description
+This is an internal package that is used to create the patterns as part
+of the installation source setup.  Installation of this package does
+not make sense.
+
+This particular package contains the Yast patterns.
+
+################################################################################
+
+%package yast2_basis
+%pattern_basetechnologies
+Summary:        YaST System Administration
+Group:          Metapackages
+Provides:       pattern() = yast2_basis
+Provides:       pattern-icon() = yast
+Provides:       pattern-order() = 1220
+Provides:       pattern-visible()
+
+Requires:       libyui-ncurses-pkg
+Requires:       yast2
+Requires:       yast2-country
+Requires:       yast2-firewall
+Requires:       yast2-hardware-detection
+Requires:       yast2-installation
+Requires:       yast2-ldap
+Requires:       yast2-mail
+Requires:       yast2-network
+Requires:       yast2-online-update
+Requires:       yast2-online-update-frontend
+Requires:       yast2-packager
+Requires:       yast2-pam
+Requires:       yast2-perl-bindings
+Requires:       yast2-pkg-bindings
+Requires:       yast2-security
+Requires:       yast2-services-manager
+Requires:       yast2-storage
+Requires:       yast2-sysconfig
+Requires:       yast2-theme-openSUSE
+Requires:       yast2-transfer
+Requires:       yast2-tune
+Requires:       yast2-update
+Requires:       yast2-users
+Requires:       yast2-xml
+Recommends:     yast2-inetd
+Recommends:     yast2-iscsi-client
+Recommends:     yast2-kerberos-client
+Recommends:     yast2-ldap-client
+Recommends:     yast2-metapackage-handler
+Recommends:     yast2-nfs-client
+Recommends:     yast2-nis-client
+Recommends:     yast2-ntp-client
+Recommends:     yast2-printer
+Recommends:     yast2-slp
+Recommends:     yast2-sudo
+# see the discussion in #386473
+Recommends:     yast2-samba-client
+Recommends:     yast2-samba-server
+# #388892
+Recommends:     yast2-vm
+# #542936
+Recommends:     yast2-packager-webpin
+Recommends:     yast2-auth-client
+Recommends:     yast2-fonts
+Recommends:     yast2-journal
+Recommends:     yast2-vpn
+Suggests:       yast2-online-update-configuration
+Suggests:       yast2-product-creator
+Suggests:       autoyast2
+Suggests:       autoyast2-installation
+Suggests:       inst-source-utils
+Suggests:       libyui-qt-pkg
+Suggests:       libyui-gtk-pkg
+Suggests:       yast2-autofs
+Suggests:       yast2-drbd
+Suggests:       yast2-firstboot
+Suggests:       yast2-mail-plugins
+Suggests:       yast2-multipath
+Suggests:       yast2-phone-services
+Suggests:       yast2-snapper
+# #381365
+Suggests:       yast2-squid
+# see extra-packages for reasons
+Suggests:       star
+Suggests:       sbl
+Suggests:       Mesa
+Suggests:       i4l-isdnlog
+Suggests:       ypserv
+Suggests:       ntp
+Suggests:       ntp-doc
+Suggests:       star
+Suggests:       alevt
+Suggests:       kradio
+Suggests:       motv
+Suggests:       nxtvepg
+Suggests:       v4l-tools
+Suggests:       install-initrd
+# for yast2-scanner
+# mandatory
+Suggests:       sane-backends
+# optionally
+Suggests:       hplip
+# optionally, open source, derived from iscan
+Suggests:       iscan-free
+# themeing for hardcore KDE lovers
+Suggests:       yast2-theme-openSUSE-Crystal
+Suggests:       yast2-theme-openSUSE-Oxygen
+Suggests:       ivtv
+Suggests:       ivtv-firmware
+# required by yast2-storage
+Suggests:       pam_mount
+%ifarch x86_64
+Suggests:       pam_fp-32bit
+%endif
+%ifarch ppc64
+Suggests:       pam_fp-64bit
+%endif
+# yast2-sound
+Suggests:       alsa-firmware
+Suggests:       alsa-tools
+# yast2-printer - printing via novell ipx
+Suggests:       ncpfs
+# yast2-kdump
+%ifarch ppc
+Suggests:       kernel-kdump
+%endif
+Suggests:       yast2-fingerprint-reader
+Suggests:       sssd
+Suggests:       snapper
+# FATE 304350
+Suggests:       sblim-sfcb
+Suggests:       cim-schema
+
+%description yast2_basis
+YaST tools for basic system administration.
+
+%files yast2_basis
+%dir /usr/share/doc/packages/patterns
+/usr/share/doc/packages/patterns/yast2_basis.txt
+
+################################################################################
+
+%package yast2_install_wf
+%pattern_basetechnologies
+Summary:        YaST Installation Packages
+Group:          Metapackages
+Provides:       pattern() = yast2_install_wf
+Provides:       pattern-icon() = yast
+Provides:       pattern-order() = 1240
+Provides:       pattern-visible()
+
+Requires:       libyui-ncurses-pkg
+Requires:       yast2-installation
+Requires:       yast2-network
+Requires:       yast2-users
+# bnc#535101
+Requires:       yast2-bootloader
+# required to write ntp.conf (bnc#723018)
+Requires:       yast2-ntp-client
+Suggests:       autoyast2-installation
+Suggests:       yast2-firewall
+Suggests:       yast2-kerberos-client
+Suggests:       yast2-ldap
+Suggests:       yast2-ldap-client
+Suggests:       yast2-nfs-client
+Suggests:       yast2-nis-client
+Suggests:       yast2-printer
+Suggests:       yast2-samba-client
+Suggests:       yast2-slp
+Suggests:       yast2-tv
+Suggests:       yast2-update
+Suggests:       autoyast2
+%ifarch x86_64
+Suggests:       samba-client-32bit
+Suggests:       samba-winbind-32bit
+%endif
+%ifarch ppc64
+Suggests:       pam_fp-64bit
+Suggests:       pam_krb5-64bit
+Suggests:       nss_ldap-64bit
+Suggests:       pam_ldap-64bit
+Suggests:       samba-client-64bit
+Suggests:       samba-winbind-64bit
+%endif
+Suggests:       tgt
+
+%description yast2_install_wf
+YaST tools for installing your system.
+
+%files yast2_install_wf
+%dir /usr/share/doc/packages/patterns
+/usr/share/doc/packages/patterns/yast2_install_wf.txt
+
+################################################################################
+
+%package x11_yast
+%pattern_basetechnologies
+Summary:        YaST User Interfaces
+Group:          Metapackages
+Provides:       pattern() = x11_yast
+Provides:       pattern-extends() = yast2_basis
+Provides:       pattern-icon() = pattern-generic
+Provides:       pattern-order() = 1320
+Supplements:    packageand(patterns-openSUSE-x11:patterns-openSUSE-yast2_basis)
+Conflicts:      pattern() = gnome
+Conflicts:      pattern() = kde
+# from data/X11-YaST
+Recommends:     libyui-qt-pkg
+Recommends:     yast2-control-center-qt
+# yast modules for the desktop
+Recommends:     yast2-scanner
+Recommends:     yast2-tv
+
+%description x11_yast
+Graphical YaST user interfaces for minimal X desktop.
+
+%files x11_yast
+%dir /usr/share/doc/packages/patterns
+/usr/share/doc/packages/patterns/x11_yast.txt
+
+################################################################################
+
+%package devel_yast
+%pattern_development
+Summary:        YaST Development
+Group:          Metapackages
+Provides:       pattern() = devel_yast
+Provides:       pattern-icon() = pattern-basis-devel
+Provides:       pattern-order() = 3460
+Provides:       pattern-visible()
+
+Recommends:     yast2-devtools
+Recommends:     yast2-testsuite
+# Bug 304645 gives the list below:
+Recommends:     yast2-pkg-bindings-devel-doc
+Recommends:     yast2-core-devel
+Recommends:     yast2-devel-doc
+Recommends:     yast2-installation-devel-doc
+Recommends:     yast2-network-devel-doc
+Recommends:     yast2-nis-server-devel-doc
+Recommends:     yast2-printer-devel-doc
+Recommends:     yast2-storage-devel
+Recommends:     yast2-perl-bindings
+Recommends:     yast2-python-bindings
+Recommends:     yast2-ruby-bindings
+Recommends:     git
+Recommends:     libzypp-devel
+Recommends:     yast2-libyui-devel
+Recommends:     yast2-ycp-ui-bindings-devel
+Recommends:     libyui-qt-devel
+Recommends:     libyui-ncurses-devel
+Suggests:       inst-source-utils
+Suggests:       createrepo
+
+%description devel_yast
+Tools and libraries for developing YaST modules, the setup and configuration tool for openSUSE.
+
+%files devel_yast
+%dir /usr/share/doc/packages/patterns
+/usr/share/doc/packages/patterns/devel_yast.txt
+
+################################################################################
+
+%prep
+
+%build
+
+%install
+mkdir -p $RPM_BUILD_ROOT/usr/share/doc/packages/patterns/
+echo 'This file marks the pattern yast2_basis to be installed.' > $RPM_BUILD_ROOT/usr/share/doc/packages/patterns/yast2_basis.txt
+echo 'This file marks the pattern yast2_install_wf to be installed.' > $RPM_BUILD_ROOT/usr/share/doc/packages/patterns/yast2_install_wf.txt
+echo 'This file marks the pattern x11_yast to be installed.' > $RPM_BUILD_ROOT/usr/share/doc/packages/patterns/x11_yast.txt
+echo 'This file marks the pattern devel_yast to be installed.' > $RPM_BUILD_ROOT/usr/share/doc/packages/patterns/devel_yast.txt
+
+%changelog


### PR DESCRIPTION
- You can skip the first commit (the files in the `package/` subdir) - this is just a raw copy from https://build.opensuse.org/package/show/YaST:Head/patterns-yast
- This is mainly about integrating the package into our usual workflow (Travis and Jenkins)
- The pattern cleanup will follow later (there are still mentioned some already dropped packages)
- The Travis build fails for now as the global pattern change has not been accepted in Factory yet (there are some new RPM macros used)