### PR TITLE
fix bug BSC#1083398

### DIFF
--- a/package/patterns-yast.changes
+++ b/package/patterns-yast.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Mar 14 16:55:22 UTC 2018 - aginies@suse.com
+
+- remove yast2-vm from Recommends as it will be only install if this
+  this is a sles-release (BSC#1083398)
+- version 20180314
+
+-------------------------------------------------------------------
 Fri Feb  9 07:44:15 UTC 2018 - jreidinger@suse.com
 
 - Remove dropped yast2-inetd (fate#323373)

--- a/package/patterns-yast.spec
+++ b/package/patterns-yast.spec
@@ -91,8 +91,6 @@ Recommends:     yast2-sudo
 # see the discussion in #386473
 Recommends:     yast2-samba-client
 Recommends:     yast2-samba-server
-# #388892
-Recommends:     yast2-vm
 # #542936
 Recommends:     yast2-vpn
 # Recommend NTP at least until boo#936378 is fixed and YaST is not trying to configure a service that's not there

--- a/package/patterns-yast.spec
+++ b/package/patterns-yast.spec
@@ -19,7 +19,7 @@
 %bcond_with betatest
 
 Name:           patterns-yast
-Version:        20180209
+Version:        20180314
 Release:        0
 Summary:        Patterns for Installation (Yast)
 License:        MIT


### PR DESCRIPTION
yast2-vm should be installed only if this is a SLES product, we don't want it on SLED. This will be handle by sles-release now.