### PR TITLE
Renamed theme packages (related to boo#1109310)

### DIFF
--- a/package/patterns-yast.changes
+++ b/package/patterns-yast.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Nov 30 08:44:52 UTC 2018 - lslezak@suse.cz
+
+- Renamed theme packages (related to boo#1109310)
+- Version 20181130
+
+-------------------------------------------------------------------
 Sun Sep 30 01:23:15 UTC 2018 - Stasiek Michalski <hellcp@opensuse.org>
 
 - Change icon for YaST devel pattern. (boo#1039994)

--- a/package/patterns-yast.spec
+++ b/package/patterns-yast.spec
@@ -19,7 +19,7 @@
 %bcond_with betatest
 
 Name:           patterns-yast
-Version:        20180613
+Version:        20181130
 Release:        0
 Summary:        Patterns for Installation (Yast)
 License:        MIT
@@ -110,7 +110,7 @@ Suggests:       yast2-snapper
 # #381365
 Suggests:       yast2-squid
 # themeing for hardcore KDE lovers
-Suggests:       yast2-theme-openSUSE-Oxygen
+Suggests:       yast2-theme-oxygen
 # see extra-packages for reasons
 Suggests:       sbl
 Suggests:       Mesa
@@ -137,11 +137,7 @@ Suggests:       snapper
 # FATE 304350
 Suggests:       sblim-sfcb
 Suggests:       cim-schema
-%if 0%{?is_opensuse}
-Requires:       yast2-branding-openSUSE
-%else
-Requires:       yast2_theme
-%endif
+Requires:       yast2-theme
 
 %description yast2_basis
 YaST tools for basic system administration.


### PR DESCRIPTION
- The theme/branding packages have been renamed (details in the [yast2-theme.spec](https://github.com/yast/yast-theme/blob/master/package/yast2-theme.spec) file)
- Now there is single `yast2-theme` instead of `yast2-branding-openSUSE` and `yast2-theme-SLE`
- The `yast2-theme-openSUSE-Oxygen` package has been renamed to `yast2-theme-oxygen`
- Version 20181130