### PR TITLE
Add yast2-alternatives

### DIFF
--- a/package/patterns-yast.changes
+++ b/package/patterns-yast.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Feb 28 15:08:34 UTC 2019 - José Iván López González <jlopez@suse.com>
+
+- Added yast2-alternatives to the "yast2_basis" pattern (opensuse
+  only) (bsc#1125040).
+- 20190228
+
+-------------------------------------------------------------------
 Fri Nov 30 08:44:52 UTC 2018 - lslezak@suse.cz
 
 - Renamed theme packages (related to boo#1109310)

--- a/package/patterns-yast.spec
+++ b/package/patterns-yast.spec
@@ -19,7 +19,7 @@
 %bcond_with betatest
 
 Name:           patterns-yast
-Version:        20181130
+Version:        20190228
 Release:        0
 Summary:        Patterns for Installation (Yast)
 License:        MIT

--- a/package/patterns-yast.spec
+++ b/package/patterns-yast.spec
@@ -50,6 +50,10 @@ Provides:       pattern-visible()
 
 Requires:       libyui-ncurses-pkg
 Requires:       yast2
+%if 0%{?is_opensuse}
+# opensuse only, see bsc#1125040
+Requires:       yast2-alternatives
+%endif
 Requires:       yast2-country
 Requires:       yast2-firewall
 Requires:       yast2-hardware-detection


### PR DESCRIPTION
## Problem

Editing the `DISPLAYMANAGER` variable in `/etc/sysconfig/displaymanager` does not make effect anymore. Instead, `update-alternatives` should be used to change the default display manager, see [release notes for Leap 15.0](https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/15.0/index.html#general).

Consequently, `yast2-sysconfig` does not allow to edit the default display manager anymore, see https://github.com/yast/yast-installation/pull/775. The package `yast2-alternatives` should be required by default to allow the user to change the default display manager (but only for openSUSE because SLE only has that package on Package Hub). 

## Solution

`yast2_basis` now requires `yast2-alternatives` for openSUSE.
