### PR TITLE
Sync the content of github and OBS (bsc#1131492)

### DIFF
--- a/package/patterns-yast.changes
+++ b/package/patterns-yast.changes
@@ -5,6 +5,18 @@ Mon Jun 11 13:23:50 UTC 2018 - jreidinger@suse.com
   (bsc#1081312)
 
 -------------------------------------------------------------------
+Thu Apr 26 15:36:01 UTC 2018 - lnussel@suse.de
+
+- move yast2-fonts in the x11_yast pattern as it pulls in freetype and stuff
+  related to it (boo#1090189)
+- remove kde and gnome conflicts in x11_yast pattern (boo#1090319)
+
+-------------------------------------------------------------------
+Thu Apr 19 09:48:27 UTC 2018 - lnussel@suse.de
+
+- Recommend chrony instead of ntp (bsc#936378)
+
+-------------------------------------------------------------------
 Tue Apr  3 04:20:05 UTC 2018 - sflees@suse.de
 
 - Suggest yast2-kdump on all arches (bsc#1078393)

--- a/package/patterns-yast.spec
+++ b/package/patterns-yast.spec
@@ -78,7 +78,6 @@ Requires:       yast2-users
 Requires:       yast2-xml
 Recommends:     yast2-auth-client
 Recommends:     yast2-auth-server
-Recommends:     yast2-fonts
 Recommends:     yast2-ftp-server
 Recommends:     yast2-iscsi-client
 Recommends:     yast2-journal
@@ -97,8 +96,8 @@ Recommends:     yast2-samba-server
 Recommends:     yast2-tftp-server
 # #542936
 Recommends:     yast2-vpn
-# Recommend NTP at least until boo#936378 is fixed and YaST is not trying to configure a service that's not there
-Recommends:     ntp
+# Recommend Chrony at least until boo#936378 is fixed and YaST is not trying to configure a service that's not there
+Recommends:     chrony
 Suggests:       yast2-online-update-configuration
 Suggests:       autoyast2
 # yast2 clone_system is expected to be installed by default (sle-beta)
@@ -118,8 +117,6 @@ Suggests:       sbl
 Suggests:       Mesa
 Suggests:       i4l-isdnlog
 Suggests:       ypserv
-Suggests:       ntp
-Suggests:       ntp-doc
 Suggests:       install-initrd
 # for yast2-scanner
 # mandatory
@@ -212,16 +209,12 @@ Provides:       pattern() = x11_yast
 Provides:       pattern-extends() = yast2_basis
 Provides:       pattern-icon() = pattern-generic
 Provides:       pattern-order() = 1320
-%if 0%{?is_opensuse}
-Supplements:    packageand(patterns-openSUSE-x11:patterns-openSUSE-yast2_basis)
-Conflicts:      pattern() = gnome
-Conflicts:      pattern() = kde
-%endif
 # from data/X11-YaST
 Recommends:     libyui-qt-pkg
 Recommends:     yast2-control-center-qt
 # yast modules for the desktop
 Recommends:     yast2-scanner
+Recommends:     yast2-fonts
 
 %description x11_yast
 Graphical YaST user interfaces for minimal X desktop.


### PR DESCRIPTION
## Problem

See [bsc#1131492](https://bugzilla.suse.com/show_bug.cgi?id=1131492)

These two changes were made for 15:GA directly in OBS, bypassing the Github repository:

https://build.suse.de/request/show/162331 (chrony instead of ntp)
https://build.suse.de/request/show/163060 (y2-fonts & desktops conflict)

Which means the repository and OBS are out of sync now for 15:GA... which has not exploded yet because there has not been a request in OBS after those two.

## Solution

Now that we are still on time (no request has been done in OBS for this package after introducing the conflict). Let's re-add the content of those submit requests to the github repo. No need to increase the version, to change the order in the changelog or to create a request in OBS (those things will probably be needed for the SP1 and master branches, but not here).
