### PR TITLE
Reintroduce lnussel's change in master (bsc#1131492)

### DIFF
--- a/package/patterns-yast.changes
+++ b/package/patterns-yast.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Tue Apr  9 09:31:53 UTC 2019 - ancor@suse.com
+
+- Reintroduced the following change done by lnussel directly in OBS
+  and overwritten by an automatic submission (bsc#1131492):
+ * Recommend chrony instead of ntp (bsc#936378)
+- 20190409
+
+-------------------------------------------------------------------
 Thu Feb 28 15:08:34 UTC 2019 - José Iván López González <jlopez@suse.com>
 
 - Added yast2-alternatives to the "yast2_basis" pattern (opensuse

--- a/package/patterns-yast.changes
+++ b/package/patterns-yast.changes
@@ -5,6 +5,18 @@ Mon Jun 11 13:23:50 UTC 2018 - jreidinger@suse.com
   (bsc#1081312)
 
 -------------------------------------------------------------------
+Thu Apr 26 15:36:01 UTC 2018 - lnussel@suse.de
+
+- move yast2-fonts in the x11_yast pattern as it pulls in freetype and stuff
+  related to it (boo#1090189)
+- remove kde and gnome conflicts in x11_yast pattern (boo#1090319)
+
+-------------------------------------------------------------------
+Thu Apr 19 09:48:27 UTC 2018 - lnussel@suse.de
+
+- Recommend chrony instead of ntp (bsc#936378)
+
+-------------------------------------------------------------------
 Tue Apr  3 04:20:05 UTC 2018 - sflees@suse.de
 
 - Suggest yast2-kdump on all arches (bsc#1078393)

--- a/package/patterns-yast.spec
+++ b/package/patterns-yast.spec
@@ -78,7 +78,6 @@ Requires:       yast2-users
 Requires:       yast2-xml
 Recommends:     yast2-auth-client
 Recommends:     yast2-auth-server
-Recommends:     yast2-fonts
 Recommends:     yast2-ftp-server
 Recommends:     yast2-iscsi-client
 Recommends:     yast2-journal
@@ -97,8 +96,8 @@ Recommends:     yast2-samba-server
 Recommends:     yast2-tftp-server
 # #542936
 Recommends:     yast2-vpn
-# Recommend NTP at least until boo#936378 is fixed and YaST is not trying to configure a service that's not there
-Recommends:     ntp
+# Recommend Chrony at least until boo#936378 is fixed and YaST is not trying to configure a service that's not there
+Recommends:     chrony
 Suggests:       yast2-online-update-configuration
 Suggests:       autoyast2
 # yast2 clone_system is expected to be installed by default (sle-beta)
@@ -118,8 +117,6 @@ Suggests:       sbl
 Suggests:       Mesa
 Suggests:       i4l-isdnlog
 Suggests:       ypserv
-Suggests:       ntp
-Suggests:       ntp-doc
 Suggests:       install-initrd
 # for yast2-scanner
 # mandatory
@@ -212,16 +209,12 @@ Provides:       pattern() = x11_yast
 Provides:       pattern-extends() = yast2_basis
 Provides:       pattern-icon() = pattern-generic
 Provides:       pattern-order() = 1320
-%if 0%{?is_opensuse}
-Supplements:    packageand(patterns-openSUSE-x11:patterns-openSUSE-yast2_basis)
-Conflicts:      pattern() = gnome
-Conflicts:      pattern() = kde
-%endif
 # from data/X11-YaST
 Recommends:     libyui-qt-pkg
 Recommends:     yast2-control-center-qt
 # yast modules for the desktop
 Recommends:     yast2-scanner
+Recommends:     yast2-fonts
 
 %description x11_yast
 Graphical YaST user interfaces for minimal X desktop.

--- a/package/patterns-yast.spec
+++ b/package/patterns-yast.spec
@@ -19,7 +19,7 @@
 %bcond_with betatest
 
 Name:           patterns-yast
-Version:        20190228
+Version:        20190409
 Release:        0
 Summary:        Patterns for Installation (Yast)
 License:        MIT


### PR DESCRIPTION
## About this pull request

This is a follow-up of #24, which already fixed the divergence in the SLE-15-GA branch. This PR was supposedly targeted to SLE-15-SP1, but I screwed it up and merged it into master (jumping one branch). Fortunately, master and SLE-15-SP1 are still in sync so this will be easy to fix.

## Original problem

See [bsc#1131492](https://bugzilla.suse.com/show_bug.cgi?id=1131492)

The root of the problem is that this change was made for 15:GA directly in OBS, bypassing the Github repository:

https://build.suse.de/request/show/162331 (chrony instead of ntp)

So it got lost in the following round of continuous integration.

## Solution

Re-introduce the change, but this time in the github repository.