### PR TITLE
Revert back to good requires

### DIFF
--- a/package/patterns-yast.changes
+++ b/package/patterns-yast.changes
@@ -1,7 +1,7 @@
 -------------------------------------------------------------------
 Thu Apr 11 14:19:26 CEST 2019 - Antoine Ginies <aginies@suse.com>
 
-- remove requires on old package yast2-branding-openSUSE
+- remove requires on old package yast2-branding-openSUSE (boo#1109310)
 
 -------------------------------------------------------------------
 Thu Apr 11 11:20:51 CEST 2019 - Antoine Ginies <aginies@suse.com>

--- a/package/patterns-yast.changes
+++ b/package/patterns-yast.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Thu Apr 11 14:19:26 CEST 2019 - Antoine Ginies <aginies@suse.com>
+
+- remove requires on old package yast2-branding-openSUSE
+
+-------------------------------------------------------------------
 Thu Apr 11 11:20:51 CEST 2019 - Antoine Ginies <aginies@suse.com>
 
 - fix installing yast2-vm per default on openSUSE (bsc#1083398)

--- a/package/patterns-yast.spec
+++ b/package/patterns-yast.spec
@@ -21,7 +21,7 @@
 Name:           patterns-yast
 
 Version:        20190411
-Release:        1
+Release:        0
 Summary:        Patterns for Installation (Yast)
 License:        MIT
 Group:          Metapackages

--- a/package/patterns-yast.spec
+++ b/package/patterns-yast.spec
@@ -140,11 +140,10 @@ Suggests:       snapper
 # FATE 304350
 Suggests:       sblim-sfcb
 Suggests:       cim-schema
-%if 0%{?is_opensuse}
+Requires:       yast2-theme
 # bsc#1083398
+%if 0%{?is_opensuse}
 Recommends:     yast2-vm
-%else
-Requires:       yast2_theme
 %endif
 
 %description yast2_basis

--- a/package/patterns-yast.spec
+++ b/package/patterns-yast.spec
@@ -21,7 +21,7 @@
 Name:           patterns-yast
 
 Version:        20190411
-Release:        0
+Release:        1
 Summary:        Patterns for Installation (Yast)
 License:        MIT
 Group:          Metapackages
@@ -141,7 +141,6 @@ Suggests:       snapper
 Suggests:       sblim-sfcb
 Suggests:       cim-schema
 %if 0%{?is_opensuse}
-Requires:       yast2-branding-openSUSE
 # bsc#1083398
 Recommends:     yast2-vm
 %else


### PR DESCRIPTION
- remove requires on old package yast2-branding-openSUSE
- revert requires on yast2-theme (should be - instead of _)
- yast2-theme should always be installed (even on SLE product)