### PR TITLE
Do not recommend yast2-fonts

### DIFF
--- a/package/patterns-yast.changes
+++ b/package/patterns-yast.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Dec 10 22:23:40 UTC 2020 - José Iván López González <jlopez@suse.com>
+
+- Do not recomment yast2-fonts (bsc#1179866).
+- 20201210
+
+-------------------------------------------------------------------
 Sun Dec 29 11:55:24 UTC 2019 - Stasiek Michalski <hellcp@mailbox.org>
 
 - Split basis pattern into basis, desktop and server (boo#1159875)

--- a/package/patterns-yast.spec
+++ b/package/patterns-yast.spec
@@ -20,7 +20,7 @@
 
 Name:           patterns-yast
 
-Version:        20191229
+Version:        20201210
 Release:        0
 Summary:        Patterns for Installation (YaST)
 License:        MIT

--- a/package/patterns-yast.spec
+++ b/package/patterns-yast.spec
@@ -106,7 +106,6 @@ Requires:       yast2-services-manager
 Requires:       yast2-sysconfig
 Requires:       yast2-users
 
-Recommends:     yast2-fonts
 Recommends:     yast2-journal
 Recommends:     yast2-printer
 Recommends:     yast2-scanner


### PR DESCRIPTION
## Problem

The package *yast2-fonts* is not maintained anymore, but it is still recommended in the desktop pattern.

* https://bugzilla.suse.com/show_bug.cgi?id=1179866


## Solution

Remove *Recommends* for *yast2-fonts*.