### PR TITLE
Drop YaST NIS dependencies from TW

### DIFF
--- a/package/patterns-yast.changes
+++ b/package/patterns-yast.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Mar 28 08:41:21 UTC 2022 - José Iván López González <jlopez@suse.com>
+
+- Neither recommend nor suggest YaST NIS packages for TW
+  (bsc#1183893).
+
+-------------------------------------------------------------------
 Mon Aug  9 11:56:10 UTC 2021 - Ladislav Slezák <lslezak@suse.cz>
 
 - 20210809

--- a/package/patterns-yast.spec
+++ b/package/patterns-yast.spec
@@ -146,7 +146,10 @@ Recommends:     yast2-iscsi-client
 Recommends:     yast2-journal
 Recommends:     yast2-ldap-client
 Recommends:     yast2-nfs-client
+# YaST NIS packages are dropped from TW (bsc#1183893)
+%if 0%{?suse_version} > 1500
 Recommends:     yast2-nis-client
+%endif
 Recommends:     yast2-ntp-client
 # see the discussion in #386473
 Recommends:     yast2-samba-client
@@ -193,7 +196,10 @@ Suggests:       yast2-firewall
 Suggests:       yast2-ldap
 Suggests:       yast2-ldap-client
 Suggests:       yast2-nfs-client
+# YaST NIS packages are dropped from TW (bsc#1183893)
+%if 0%{?suse_version} > 1500
 Suggests:       yast2-nis-client
+%endif
 Suggests:       yast2-printer
 Suggests:       yast2-samba-client
 Suggests:       yast2-slp


### PR DESCRIPTION
## Problem

YaST NIS packages (i.e., *yast2-nis-server* and *yast2-nis-client*) were dropped from TW, see https://github.com/yast/yast-nis-server/pull/30 and https://github.com/yast/yast-nis-client/pull/63. But some *patterns* still recommend or suggest such packages.

## Solution

Neither recommend nor suggest such packages  for TW package.

Note: This PR will not be merged into master yet. The temporary branch pre-SLE-15-SP4 will be merged into master after SLE-15-SP4 branching. Do not forget to bump the version while merging.

