### PR TITLE
Drop the NIS package dependencies

### DIFF
--- a/package/patterns-yast.changes
+++ b/package/patterns-yast.changes
@@ -1,8 +1,9 @@
 -------------------------------------------------------------------
-Mon Mar 28 08:41:21 UTC 2022 - José Iván López González <jlopez@suse.com>
+Mon Apr 11 07:29:19 UTC 2022 - José Iván López González <jlopez@suse.com>
 
 - Neither recommend nor suggest YaST NIS packages for TW
   (bsc#1183893).
+- 20220411
 
 -------------------------------------------------------------------
 Mon Aug  9 11:56:10 UTC 2021 - Ladislav Slezák <lslezak@suse.cz>

--- a/package/patterns-yast.changes
+++ b/package/patterns-yast.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Mar 28 08:41:21 UTC 2022 - José Iván López González <jlopez@suse.com>
+
+- Neither recommend nor suggest YaST NIS packages for TW
+  (bsc#1183893).
+
+-------------------------------------------------------------------
 Mon Aug  9 11:56:10 UTC 2021 - Ladislav Slezák <lslezak@suse.cz>
 
 - 20210809

--- a/package/patterns-yast.spec
+++ b/package/patterns-yast.spec
@@ -146,7 +146,10 @@ Recommends:     yast2-iscsi-client
 Recommends:     yast2-journal
 Recommends:     yast2-ldap-client
 Recommends:     yast2-nfs-client
+# YaST NIS packages are dropped from TW (bsc#1183893)
+%if 0%{?suse_version} > 1500
 Recommends:     yast2-nis-client
+%endif
 Recommends:     yast2-ntp-client
 # see the discussion in #386473
 Recommends:     yast2-samba-client
@@ -193,7 +196,10 @@ Suggests:       yast2-firewall
 Suggests:       yast2-ldap
 Suggests:       yast2-ldap-client
 Suggests:       yast2-nfs-client
+# YaST NIS packages are dropped from TW (bsc#1183893)
+%if 0%{?suse_version} > 1500
 Suggests:       yast2-nis-client
+%endif
 Suggests:       yast2-printer
 Suggests:       yast2-samba-client
 Suggests:       yast2-slp

--- a/package/patterns-yast.spec
+++ b/package/patterns-yast.spec
@@ -147,7 +147,8 @@ Recommends:     yast2-journal
 Recommends:     yast2-ldap-client
 Recommends:     yast2-nfs-client
 # YaST NIS packages are dropped from TW (bsc#1183893)
-%if 0%{?suse_version} > 1500
+# it is only available in SLE15/Leap15
+%if 0%{?sle_version}
 Recommends:     yast2-nis-client
 %endif
 Recommends:     yast2-ntp-client
@@ -197,7 +198,8 @@ Suggests:       yast2-ldap
 Suggests:       yast2-ldap-client
 Suggests:       yast2-nfs-client
 # YaST NIS packages are dropped from TW (bsc#1183893)
-%if 0%{?suse_version} > 1500
+# it is only available in SLE15/Leap15
+%if 0%{?sle_version}
 Suggests:       yast2-nis-client
 %endif
 Suggests:       yast2-printer

--- a/package/patterns-yast.spec
+++ b/package/patterns-yast.spec
@@ -19,7 +19,7 @@
 %bcond_with betatest
 
 Name:           patterns-yast
-Version:        20210809
+Version:        20220411
 Release:        0
 Summary:        Patterns for Installation (YaST)
 License:        MIT


### PR DESCRIPTION
## Problem

- The NIS packages have been dropped from Factory
- https://bugzilla.suse.com/show_bug.cgi?id=1183893


## Solution

- Drop the dependencies as well in Factory, keep the them in SLE15
